### PR TITLE
Add per-axis amplitude multipliers to geometry displacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,10 +405,10 @@ nw_wrld/
 │   ├── projector/              # Visual output window
 │   │   ├── Projector.js        # Main projector logic
 │   │   ├── helpers/
-│   │   │   ├── moduleBase.js   # Base class (the foundation)
-│   │   │   └── threeBase.js    # Three.js base class
+│   │   │   ├── moduleBase.ts   # Base class (the foundation)
+│   │   │   └── threeBase.ts    # Three.js base class
 │   │   └── templates/
-│   │       └── ThreeTemplate.js # 3D module template
+│   │       └── ThreeTemplate.ts # 3D module template
 │   │
 │   ├── main/                   # Electron main process
 │   │   ├── InputManager.js     # MIDI/OSC input handling

--- a/src/dashboard/core/hooks/useWorkspaceModules.ts
+++ b/src/dashboard/core/hooks/useWorkspaceModules.ts
@@ -294,7 +294,7 @@ export const useWorkspaceModules = ({
           });
         } catch {}
         try {
-          maybeHot.accept("../../../projector/helpers/threeBase.js", () => {
+          maybeHot.accept("../../../projector/helpers/threeBase", () => {
             loadModules();
           });
         } catch {}

--- a/src/main/mainProcess/ipcBridge/registerAppBridge.ts
+++ b/src/main/mainProcess/ipcBridge/registerAppBridge.ts
@@ -14,7 +14,7 @@ export function registerAppBridge(): void {
   ipcMain.on("bridge:app:getBaseMethodNames", (event) => {
     try {
       const moduleBasePath = path.join(srcDir, "projector", "helpers", "moduleBase.ts");
-      const threeBasePath = path.join(srcDir, "projector", "helpers", "threeBase.js");
+      const threeBasePath = path.join(srcDir, "projector", "helpers", "threeBase.ts");
       const moduleBaseContent = fs.readFileSync(moduleBasePath, "utf-8");
       const threeBaseContent = fs.readFileSync(threeBasePath, "utf-8");
       const methodRegex = /{\s*name:\s*"([^"]+)",\s*executeOnLoad:/g;
@@ -136,7 +136,7 @@ export function registerAppBridge(): void {
       const methodNameEscaped = escapeRegExpLiteral(safeMethodName);
 
       const moduleBasePath = path.join(srcDir, "projector", "helpers", "moduleBase.ts");
-      const threeBasePath = path.join(srcDir, "projector", "helpers", "threeBase.js");
+      const threeBasePath = path.join(srcDir, "projector", "helpers", "threeBase.ts");
 
       let filePath: string | null = null;
       let fileContent: string | null = null;

--- a/src/projector/moduleSandboxEntry.ts
+++ b/src/projector/moduleSandboxEntry.ts
@@ -1,5 +1,5 @@
 import ModuleBase from "./helpers/moduleBase";
-import BaseThreeJsModule from "./helpers/threeBase.js";
+import BaseThreeJsModule from "./helpers/threeBase";
 import * as THREE from "three";
 import p5 from "p5";
 import * as d3 from "d3";

--- a/src/projector/templates/ThreeTemplate.ts
+++ b/src/projector/templates/ThreeTemplate.ts
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import BaseThreeJsModule from "../helpers/threeBase.js";
+import BaseThreeJsModule from "../helpers/threeBase";
 
 export class ThreeTemplate extends BaseThreeJsModule {
   static title = "ThreeTemplate";


### PR DESCRIPTION
## Summary

What does this PR change and why?

## Target branch

- [x] This PR targets `develop` (required)

## Type of change

- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Docs / tooling

## How to test

Steps to validate the change:

## Checklist

- [ ] I ran `npm run typecheck:all`
- [ ] I ran `npm run test:unit`
- [ ] I ran `npm run build:renderer` (or explain why not)
- [ ] I updated docs if needed
- [ ] I added/updated tests if needed

## Notes for reviewers
The time parameter introduced here is currently scoped locally and handled inline within the `displacementParams` method.

Conceptually, this could later be factored into a shared helper for modules, enabling reusable time-based primitives (e.g. envelopes or LFOs). This PR does not attempt that refactor and keeps all timing logic self-contained.
Anything risky, or areas to pay attention to:

## Review context (please read / use as ground truth)

- `README.md`
- `MODULE_DEVELOPMENT.md`
- `CONTRIBUTING.md`
- `RUNTIME_TS_TESTING_GUIDELINES.md`
