### PR TITLE
Modify unit test script to work on all platforms

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:runtime": "tsc -p tsconfig.runtime.json",
     "build:scripts": "tsc -p tsconfig.scripts.json",
     "check:runtime-lane": "npm run build:scripts && node dist/scripts/checkRuntimeLaneNoDuplicateSources.js",
-    "test:unit": "npm run build:runtime && npm run check:runtime-lane && node --test test",
+    "test:unit": "npm run build:runtime && npm run check:runtime-lane && node --test test/*.test.js",
     "test:e2e": "npm run build:runtime && npm run build && playwright test",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",


### PR DESCRIPTION
One liner to make the unit test script work on Windows as well as Unix and Linux.

Current behavior on Windows after running `npm run test:unit` on develop is this output:

```console
Error: Cannot find module 'C:\Users\userdir\projects\nw_wrld\test'
    at Function._resolveFilename (node:internal/modules/cjs/loader:1249:15)
    at Function._load (node:internal/modules/cjs/loader:1075:27)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:218:24)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:170:5)
    at node:internal/main/run_main_module:36:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v22.11.0
✖ test (52.3661ms)
  'test failed'

ℹ tests 1
ℹ suites 0
ℹ pass 0
ℹ fail 1
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 59.8752

✖ failing tests:

test at test:1:1
✖ test (52.3661ms)
  'test failed'
````

Node mistakes `test` for a module instead of a folder.

This PR changes the script to use a glob pattern instead which works on Windows, and should still work the same on Unix and Linux too.

## Summary

What does this PR change and why?

## Target branch

- [x] This PR targets `develop` (required)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs / tooling

## How to test

Steps to validate the change:

## Checklist

- [x] I ran `npm run typecheck:all`
- [x] I ran `npm run test:unit`
- [x] I ran `npm run build:renderer` (or explain why not)
- [ ] I updated docs if needed
- [ ] I added/updated tests if needed

## Notes for reviewers

The pattern `test/*.test.js` is used here because all unit tests currently live in the root of the test folder. If the intent is to keep it that way, nothing to worry about here, but if there will be subdirectories for unit tests in the future this can be updated to the recursive `test/**/*.test.js` pattern.

## Review context (please read / use as ground truth)

- `README.md`
- `MODULE_DEVELOPMENT.md`
- `CONTRIBUTING.md`
- `RUNTIME_TS_TESTING_GUIDELINES.md`
