### PR TITLE
Release 0.7.0-beta: fix universal mac build

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,8 @@
       "hardenedRuntime": true,
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.inherit.plist",
-      "notarize": true
+      "notarize": true,
+      "x64ArchFiles": "**/jazz-midi/**/*.node"
     },
     "win": {
       "target": [

--- a/test/packagingConfig.test.js
+++ b/test/packagingConfig.test.js
@@ -27,6 +27,7 @@ test("packaging config references build resources that exist", () => {
   assert.equal(typeof mac.entitlements, "string");
   assert.equal(typeof mac.entitlementsInherit, "string");
   assert.equal(typeof mac.icon, "string");
+  assert.match(String(mac.x64ArchFiles), /jazz-midi/);
 
   const win = build && build.win ? build.win : null;
   assert.equal(typeof win, "object");


### PR DESCRIPTION
Declare jazz-midi binaries as x64ArchFiles so electron-builder 26 can merge the universal app.