### PR TITLE
test: use junction for symlink escape test on Windows

### DIFF
--- a/test/pathSafetyValidation.test.js
+++ b/test/pathSafetyValidation.test.js
@@ -43,7 +43,7 @@ test("resolveWithinDir rejects symlink escape", () => {
     fs.writeFileSync(target, "x", "utf-8");
 
     const linkPath = path.join(base, "link");
-    fs.symlinkSync(outside, linkPath, "dir");
+    fs.symlinkSync(outside, linkPath, process.platform === "win32" ? "junction" : "dir");
 
     assert.equal(resolveWithinDir(base, "link/secret.txt"), null);
   } finally {


### PR DESCRIPTION
## Summary

When running the tests on Windows 11, the tests require elevated permissions for `fs.symlinkSync`, using junction does not

## Target branch

- [x] This PR targets `develop` (required)

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs / tooling

## How to test

Steps to validate the change:

## Checklist

- [x] I ran `npm run typecheck:all`
- [x] I ran `npm run test:unit`
- [x] I ran `npm run build:renderer` (or explain why not)
- [ ] I updated docs if needed
- [ ] I added/updated tests if needed

## Notes for reviewers

relates to #74 

## Review context (please read / use as ground truth)

- `README.md`
- `GETTING_STARTED.md`
- `MODULE_DEVELOPMENT.md`
- `CONTRIBUTING.md`
- `RUNTIME_TS_TESTING_GUIDELINES.md`
- `E2E_TESTING_GUIDELINES.md`
