### PR TITLE
show units when available

### DIFF
--- a/src/dashboard/modals/MethodConfiguratorModal.tsx
+++ b/src/dashboard/modals/MethodConfiguratorModal.tsx
@@ -50,6 +50,7 @@ type OptionDef = {
   max?: number;
   values?: string[];
   allowRandomization?: boolean;
+  unit?: string;
 };
 
 type ModuleMethod = {
@@ -338,6 +339,7 @@ export const MethodConfiguratorModal = ({
               min: typeof oObj.min === "number" ? oObj.min : undefined,
               max: typeof oObj.max === "number" ? oObj.max : undefined,
               allowRandomization: oObj.allowRandomization === true,
+              unit: oObj.unit != null ? String(oObj.unit) : undefined,
             };
           })
           .filter((o: OptionDef | null): o is OptionDef => Boolean(o));


### PR DESCRIPTION
## Summary

Turns out the UI was not showing the units when they were available

**before:**

<img width="161" height="107" alt="image" src="https://github.com/user-attachments/assets/2270b9e9-a434-4c28-8aa7-ec3c49301040" />


**after:**

<img width="162" height="95" alt="image" src="https://github.com/user-attachments/assets/652e60e2-1c4c-4609-82ed-e96f5232f30f" />


## Target branch

- [x] This PR targets `develop` (required)

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs / tooling

## How to test

Steps to validate the change:

## Checklist

- [x] I ran `npm run typecheck:all`
- [x] I ran `npm run test:unit`
- [x] I ran `npm run build:renderer` (or explain why not)
- [ ] I updated docs if needed
- [ ] I added/updated tests if needed

## Notes for reviewers

Anything risky, or areas to pay attention to: no

## Review context (please read / use as ground truth)

- `README.md`
- `GETTING_STARTED.md`
- `MODULE_DEVELOPMENT.md`
- `CONTRIBUTING.md`
- `RUNTIME_TS_TESTING_GUIDELINES.md`
- `E2E_TESTING_GUIDELINES.md`
