### PR TITLE
fix color function in pulsing circle example

### DIFF
--- a/MODULE_DEVELOPMENT.md
+++ b/MODULE_DEVELOPMENT.md
@@ -161,7 +161,7 @@ class PulsingCircle extends ModuleBase {
     this.canvas = null;
     this.ctx = null;
     this.circleScale = 1;
-    this.color = "#00FF00";
+    this.circleColor = "#00FF00"
     this.init();
   }
 
@@ -189,7 +189,7 @@ class PulsingCircle extends ModuleBase {
     // Draw circle
     ctx.beginPath();
     ctx.arc(width / 2, height / 2, radius, 0, Math.PI * 2);
-    ctx.fillStyle = this.color;
+    ctx.fillStyle = this.circleColor;
     ctx.fill();
   }
 
@@ -223,7 +223,7 @@ class PulsingCircle extends ModuleBase {
   }
 
   color({ color = "#00FF00" }) {
-    this.color = color;
+    this.circleColor = color;
     this.draw();
   }
 

--- a/MODULE_DEVELOPMENT.md
+++ b/MODULE_DEVELOPMENT.md
@@ -161,7 +161,7 @@ class PulsingCircle extends ModuleBase {
     this.canvas = null;
     this.ctx = null;
     this.circleScale = 1;
-    this.circleColor = "#00FF00"
+    this.circleColor = "#00FF00";
     this.init();
   }
 


### PR DESCRIPTION
## Summary

The PulsingCircle.js example color function does not work because the function name `circle()` overlaps with the property `this.circle`.

## Target branch

- [x] This PR targets `develop` (required)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs / tooling

## How to test

Steps to validate the change:

## Checklist

- [ ] I ran `npm run typecheck:all`
- [ ] I ran `npm run test:unit`
- [ ] I ran `npm run build:renderer` (or explain why not)
- [x] I updated docs if needed
- [ ] I added/updated tests if needed

## Notes for reviewers

Anything risky, or areas to pay attention to: no

## Review context (please read / use as ground truth)

- `README.md`
- `GETTING_STARTED.md`
- `MODULE_DEVELOPMENT.md`
- `CONTRIBUTING.md`
- `RUNTIME_TS_TESTING_GUIDELINES.md`
- `E2E_TESTING_GUIDELINES.md`
